### PR TITLE
Add a cache busting when fetching `lastUpdateTime`

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -441,7 +441,7 @@ exports.sourceNodes = async (gatsbyApi) => {
     const { data } = await execute({
         operationName: 'craftState',
         query: 'query craftState { configVersion  lastUpdateTime }',
-        variables: { bustCache: Math.random() }
+        variables: { now: Date.now() }
     });
     const remoteConfigVersion = data.configVersion;
     const remoteContentUpdateTime = data.lastUpdateTime;

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -441,7 +441,7 @@ exports.sourceNodes = async (gatsbyApi) => {
     const { data } = await execute({
         operationName: 'craftState',
         query: 'query craftState { configVersion  lastUpdateTime }',
-        variables: {}
+        variables: { bustCache: Math.random() }
     });
     const remoteConfigVersion = data.configVersion;
     const remoteContentUpdateTime = data.lastUpdateTime;


### PR DESCRIPTION
There might be a more elegant fix for this, but something similar to this should solve: https://github.com/craftcms/gatsby-source-craft/issues/8