### PR TITLE
Patch query headers to prevent caching lastUpdateTime queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 This Gatsby source plugin provides an integration with [Craft CMS](https://craftcms.com). It uses Craft’s [GraphQL API](https://docs.craftcms.com/v3/graphql.html) to make content within Craft available to Gatsby-powered front ends.
 
-It requires Craft CMS 3.5.11 or later, and for the corresponding [Gatsby Helper](https://github.com/craftcms/gatsby-helper) plugin to be installed on the Craft site.
+It requires Craft CMS 3.5.16 or later, and for the corresponding [Gatsby Helper](https://github.com/craftcms/gatsby-helper) plugin to be installed on the Craft site.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 This Gatsby source plugin provides an integration with [Craft CMS](https://craftcms.com). It uses Craft’s [GraphQL API](https://docs.craftcms.com/v3/graphql.html) to make content within Craft available to Gatsby-powered front ends.
 
-It requires for the corresponding [Gatsby Helper](https://github.com/craftcms/gatsby-helper) plugin to be installed on the Craft site.
+It requires Craft CMS 3.5.11 or later, and for the corresponding [Gatsby Helper](https://github.com/craftcms/gatsby-helper) plugin to be installed on the Craft site.
 
 ---
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -58,7 +58,7 @@ async function getGatsbyNodeTypes() {
     }
     const queryResponse = await execute({
         operationName: 'sourceNodeData',
-        query: 'query sourceNodeData { sourceNodeInformation { node list filterArgument filterTypeExpression  targetInterface } primarySiteId }',
+        query: 'query sourceNodeData { sourceNodeInformation { node list filterArgument filterTypeExpression targetInterface } primarySiteId }',
         variables: {},
         additionalHeaders: {}
     });

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -58,8 +58,9 @@ async function getGatsbyNodeTypes() {
     }
     const queryResponse = await execute({
         operationName: 'sourceNodeData',
-        query: 'query sourceNodeData { sourceNodeInformation { node list filterArgument filterTypeExpression  targetInterface } primarySiteId}',
-        variables: {}
+        query: 'query sourceNodeData { sourceNodeInformation { node list filterArgument filterTypeExpression  targetInterface } primarySiteId }',
+        variables: {},
+        additionalHeaders: {}
     });
     if (!(queryResponse.data && queryResponse.data.sourceNodeInformation)) {
         return ([]);

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -268,10 +268,11 @@ async function writeCompiledQueries(nodeDocs) {
  * @param operation
  */
 async function execute(operation) {
-    let { operationName, query, variables = {} } = operation;
+    let { operationName, query, variables = {}, additionalHeaders = {} } = operation;
     const headers = {
         "Content-Type": "application/json",
         Authorization: `Bearer ${craftGqlToken}`,
+        ...additionalHeaders
     };
     // Set the token, if it exists
     if (previewToken) {
@@ -440,8 +441,11 @@ exports.sourceNodes = async (gatsbyApi) => {
     reporter.info("Checking Craft config version.");
     const { data } = await execute({
         operationName: 'craftState',
-        query: 'query craftState { configVersion  lastUpdateTime }',
-        variables: {}
+        query: 'query craftState { configVersion lastUpdateTime }',
+        variables: {},
+        additionalHeaders: {
+            "X-Craft-Gql-Cache": "no-cache"
+        }
     });
     const remoteConfigVersion = data.configVersion;
     const remoteContentUpdateTime = data.lastUpdateTime;
@@ -461,7 +465,10 @@ exports.sourceNodes = async (gatsbyApi) => {
                 nodesUpdatedSince (since: "${localContentUpdateTime}") { nodeId nodeType siteId}
                 nodesDeletedSince (since: "${localContentUpdateTime}") { nodeId nodeType siteId}
             }`,
-            variables: {}
+            variables: {},
+            additionalHeaders: {
+                "X-Craft-Gql-Cache": "no-cache"
+            }
         });
         const updatedNodes = data.nodesUpdatedSince;
         const deletedNodes = data.nodesDeletedSince;

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -106,8 +106,11 @@ async function getGatsbyNodeTypes() {
 
     const queryResponse = await execute({
         operationName: 'sourceNodeData',
-        query: 'query sourceNodeData { sourceNodeInformation { node list filterArgument filterTypeExpression  targetInterface } primarySiteId}',
-        variables: {}
+        query: 'query sourceNodeData { sourceNodeInformation { node list filterArgument filterTypeExpression targetInterface } primarySiteId }',
+        variables: {},
+        additionalHeaders: {
+            "X-Craft-Gql-Cache": "no-cache"
+        }
     });
 
     if (!(queryResponse.data && queryResponse.data.sourceNodeInformation)) {
@@ -355,12 +358,13 @@ async function writeCompiledQueries(nodeDocs: IGatsbyNodeDefinition[]) {
  * Execute a GraphQL query
  * @param operation
  */
-async function execute(operation: { operationName: string, query: string, variables: object }) {
-    let {operationName, query, variables = {}} = operation;
+async function execute(operation: { operationName: string, query: string, variables: object, additionalHeaders: object }) {
+    let {operationName, query, variables = {}, additionalHeaders = {} } = operation;
 
     const headers: { [key: string]: string } = {
         "Content-Type": "application/json",
         Authorization: `Bearer ${craftGqlToken}`,
+        ...additionalHeaders
     };
 
     // Set the token, if it exists
@@ -564,8 +568,11 @@ exports.sourceNodes = async (gatsbyApi: NodePluginArgs) => {
 
     const {data} = await execute({
         operationName: 'craftState',
-        query: 'query craftState { configVersion  lastUpdateTime }',
-        variables: {}
+        query: 'query craftState { configVersion lastUpdateTime }',
+        variables: {},
+        additionalHeaders: {
+            "X-Craft-Gql-Cache": "no-cache"
+        }
     });
 
     const remoteConfigVersion = data.configVersion;
@@ -588,7 +595,10 @@ exports.sourceNodes = async (gatsbyApi: NodePluginArgs) => {
                 nodesUpdatedSince (since: "${localContentUpdateTime}") { nodeId nodeType siteId}
                 nodesDeletedSince (since: "${localContentUpdateTime}") { nodeId nodeType siteId}
             }`,
-            variables: {}
+            variables: {},
+            additionalHeaders: {
+                "X-Craft-Gql-Cache": "no-cache"
+            }
         });
 
         const updatedNodes = data.nodesUpdatedSince as ModifiedNodeInfo[];

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -108,9 +108,7 @@ async function getGatsbyNodeTypes() {
         operationName: 'sourceNodeData',
         query: 'query sourceNodeData { sourceNodeInformation { node list filterArgument filterTypeExpression targetInterface } primarySiteId }',
         variables: {},
-        additionalHeaders: {
-            "X-Craft-Gql-Cache": "no-cache"
-        }
+        additionalHeaders: {}
     });
 
     if (!(queryResponse.data && queryResponse.data.sourceNodeInformation)) {


### PR DESCRIPTION
Takes advantage of the new `X-Craft-Gql-Cache: no-cache` header in Craft 3.5.16 to prevent queries from being cached that shouldn't be.

Fixes https://github.com/craftcms/gatsby-source-craft/issues/8