### PR TITLE
chore: move gatsby to peerdeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,16 +27,16 @@
   },
   "dependencies": {
     "fs-extra": "^9.0.1",
-    "gatsby": "^2.24.68",
     "gatsby-graphql-source-toolkit": "^0.6.0",
     "gatsby-source-filesystem": "^2.3.25",
-    "node-fetch": "^2.6.1",
-    "react": "^16.12.0",
-    "react-dom": "^16.12.0"
+    "node-fetch": "^2.6.1"
   },
   "devDependencies": {
     "@types/fs-extra": "^9.0.1",
     "dotenv": "^8.2.0",
     "prettier": "2.0.5"
+  },
+  "peerDependencies": {
+    "gatsby": "^2.24.68"
   }
 }


### PR DESCRIPTION
### Description
Adding gatsby as a dependency could lead to strange behavior when the current gatsby version is lower than what specified in the plugin. This will also give issues when a new gatsby major comes out.

Removed react as dependencies as well as I don't think it's used. If so, add them to peerdeps for the same reason as above.



### Related issues

