### PR TITLE
Cannot source pending nodes

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -167,7 +167,7 @@ async function getGatsbyNodeTypes() {
             queries = fragmentInfo.fragment;
             // and define queries for the concrete type
             if (sourceNodeInformation.node) {
-                queries += `query NODE_${typeName} { ${sourceNodeInformation.node}(id: $id siteId: $siteId) { ... ${fragmentInfo.fragmentName}  } }
+                queries += `query NODE_${typeName} { ${sourceNodeInformation.node}(id: $id siteId: $siteId, status: ["live", "pending"]) { ... ${fragmentInfo.fragmentName}  } }
                 `;
             }
             let typeFilter = '';

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -165,19 +165,6 @@ async function getGatsbyNodeTypes() {
             let queries = '';
             let fragmentInfo = fragmentHelper(typeName, canBeDraft);
             queries = fragmentInfo.fragment;
-            // and define queries for the concrete type
-            if (sourceNodeInformation.node) {
-                queries += `query NODE_${typeName} { ${sourceNodeInformation.node}(id: $id siteId: $siteId, status: ["live", "pending"]) { ... ${fragmentInfo.fragmentName}  } }
-                `;
-            }
-            let typeFilter = '';
-            if (sourceNodeInformation.filterArgument) {
-                let regexp = new RegExp(sourceNodeInformation.filterTypeExpression);
-                const matches = typeName.match(regexp);
-                if (matches && matches[1]) {
-                    typeFilter = sourceNodeInformation.filterArgument + ': "' + matches[1] + '"';
-                }
-            }
             // Add sourcing parameters defined by user to the sourcing queries
             let configuredParameters = {};
             // Interfaces first
@@ -192,6 +179,19 @@ async function getGatsbyNodeTypes() {
             let configuredParameterString = '';
             for (const [key, value] of Object.entries(configuredParameters)) {
                 configuredParameterString += `${key}: ${value} `;
+            }
+            // and define queries for the concrete type
+            if (sourceNodeInformation.node) {
+                queries += `query NODE_${typeName} { ${sourceNodeInformation.node}(id: $id siteId: $siteId ${configuredParameterString}) { ... ${fragmentInfo.fragmentName}  } }
+                `;
+            }
+            let typeFilter = '';
+            if (sourceNodeInformation.filterArgument) {
+                let regexp = new RegExp(sourceNodeInformation.filterTypeExpression);
+                const matches = typeName.match(regexp);
+                if (matches && matches[1]) {
+                    typeFilter = sourceNodeInformation.filterArgument + ': "' + matches[1] + '"';
+                }
             }
             queries += `query LIST_${typeName} { ${sourceNodeInformation.list}(${typeFilter} limit: $limit, offset: $offset site: ${craftSites} ${configuredParameterString}) { ... ${fragmentInfo.fragmentName} } }
             `;

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -230,24 +230,6 @@ async function getGatsbyNodeTypes() {
 
             queries = fragmentInfo.fragment;
 
-            // and define queries for the concrete type
-            if (sourceNodeInformation.node) {
-                queries += `query NODE_${typeName} { ${sourceNodeInformation.node}(id: $id siteId: $siteId, status: ["live", "pending"]) { ... ${fragmentInfo.fragmentName}  } }
-                `;
-            }
-
-            let typeFilter = '';
-
-            if (sourceNodeInformation.filterArgument) {
-                let regexp = new RegExp(sourceNodeInformation.filterTypeExpression as string);
-                const matches = typeName.match(regexp);
-
-
-                if (matches && matches[1]) {
-                    typeFilter = sourceNodeInformation.filterArgument + ': "' + matches[1] + '"';
-                }
-            }
-
             // Add sourcing parameters defined by user to the sourcing queries
             let configuredParameters = {};
 
@@ -265,6 +247,23 @@ async function getGatsbyNodeTypes() {
             let configuredParameterString = '';
             for (const [key, value] of Object.entries(configuredParameters)) {
                 configuredParameterString += `${key}: ${value} `;
+            }
+
+            // and define queries for the concrete type
+            if (sourceNodeInformation.node) {
+                queries += `query NODE_${typeName} { ${sourceNodeInformation.node}(id: $id siteId: $siteId ${configuredParameterString}) { ... ${fragmentInfo.fragmentName}  } }
+                `;
+            }
+
+            let typeFilter = '';
+
+            if (sourceNodeInformation.filterArgument) {
+                let regexp = new RegExp(sourceNodeInformation.filterTypeExpression as string);
+                const matches = typeName.match(regexp);
+
+                if (matches && matches[1]) {
+                    typeFilter = sourceNodeInformation.filterArgument + ': "' + matches[1] + '"';
+                }
             }
 
             queries += `query LIST_${typeName} { ${sourceNodeInformation.list}(${typeFilter} limit: $limit, offset: $offset site: ${craftSites} ${configuredParameterString}) { ... ${fragmentInfo.fragmentName} } }

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -232,7 +232,7 @@ async function getGatsbyNodeTypes() {
 
             // and define queries for the concrete type
             if (sourceNodeInformation.node) {
-                queries += `query NODE_${typeName} { ${sourceNodeInformation.node}(id: $id siteId: $siteId) { ... ${fragmentInfo.fragmentName}  } }
+                queries += `query NODE_${typeName} { ${sourceNodeInformation.node}(id: $id siteId: $siteId, status: ["live", "pending"]) { ... ${fragmentInfo.fragmentName}  } }
                 `;
             }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16573,6 +16573,12 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "typescript": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
+      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "dev": true
+    },
     "unbox-primitive": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -34,9 +34,10 @@
   "devDependencies": {
     "@types/fs-extra": "^9.0.1",
     "dotenv": "^8.2.0",
-    "prettier": "2.0.5",
     "gatsby": "^3.0.0",
-    "graphql": "^15.0.0"
+    "graphql": "^15.0.0",
+    "prettier": "2.0.5",
+    "typescript": "^4.2.4"
   },
   "peerDependencies": {
     "gatsby": "^3.0.0"


### PR DESCRIPTION
### Description

Attempt at fixing #30 

TDLR; This looks like this issue is caused by the [sourcing changes delta](https://github.com/gatsbyjs/gatsby-graphql-toolkit#sourcing-changes-delta) in `gatsby-graphql-source-toolkit`. The default `query NODE_` doesn't specify a status which causes the query to use the default behavior of `entry.find()`. This seems to only include entries with a status of `live` which will cause node lookups for pending entries to fail.

My solution here was to simply pass in the same `sourcingParams` attribute that was used for the `LIST_` variants... but there are some obvious downsides to this such as passing `orderBy` params etc.

In my testing this resolved the issue.


### Related issues

craftcms/gatsby-helper#13
